### PR TITLE
Suppress compiler warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,6 +83,10 @@ lucumaTypedGenerate := {
 ThisBuild / tlFatalWarnings := false
 ThisBuild / scalacOptions += "-language:implicitConversions"
 
+// Suppress compiler warnings. This is all generated code and there are thousands of
+// "unused" warnings, etc. You may want to comment this out to troubleshoot the ST conversion.
+ThisBuild / scalacOptions += "-Wconf:any:silent"
+
 lazy val root = project
   .in(file("."))
   .enablePlugins(NoPublishPlugin)


### PR DESCRIPTION
The scalablyTyped generated code generates lots of warnings, and they are repeated in multiple steps of the CI run. Since it is ALL generated code, I'm suppressing the warnings so that we can find actual errors in the CI runs. Sometimes we ran out of log space and can't see the error at all.